### PR TITLE
Add single simultaneous replica movement strategy

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -13,7 +13,6 @@ import com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeOneAboveMinI
 import com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeSmallReplicaMovementStrategy;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
-
 import com.linkedin.kafka.cruisecontrol.executor.strategy.SingleReplicaMovementStrategy;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.common.config.ConfigDef;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -13,6 +13,8 @@ import com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeOneAboveMinI
 import com.linkedin.kafka.cruisecontrol.executor.strategy.PrioritizeSmallReplicaMovementStrategy;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
+
+import com.linkedin.kafka.cruisecontrol.executor.strategy.SingleReplicaMovementStrategy;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
@@ -207,7 +209,9 @@ public final class ExecutorConfig {
       .add(PrioritizeSmallReplicaMovementStrategy.class.getName())
       .add(PrioritizeMinIsrWithOfflineReplicasStrategy.class.getName())
       .add(PrioritizeOneAboveMinIsrWithOfflineReplicasStrategy.class.getName())
-      .add(BaseReplicaMovementStrategy.class.getName()).toString();
+      .add(BaseReplicaMovementStrategy.class.getName())
+      .add(SingleReplicaMovementStrategy.class.getName())
+      .toString();
   public static final String REPLICA_MOVEMENT_STRATEGIES_DOC = "A list of supported strategies used to determine execution"
       + " order for generated partition movement tasks.";
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BasicProvisioner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/BasicProvisioner.java
@@ -7,7 +7,6 @@ package com.linkedin.kafka.cruisecontrol.detector;
 import com.linkedin.cruisecontrol.common.config.ConfigDef;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.analyzer.ProvisionRecommendation;
-import java.util.Collections;
 import java.util.Map;
 
 import static com.linkedin.cruisecontrol.common.config.ConfigDef.Type.CLASS;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/StatefulSetBrokerProvisioner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/StatefulSetBrokerProvisioner.java
@@ -6,7 +6,6 @@ package com.linkedin.kafka.cruisecontrol.detector;
 
 import com.linkedin.cruisecontrol.common.config.ConfigException;
 import com.linkedin.kafka.cruisecontrol.analyzer.ProvisionRecommendation;
-
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
@@ -14,10 +13,8 @@ import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.util.Map;
 
 import static com.linkedin.kafka.cruisecontrol.detector.ProvisionerState.State.COMPLETED;
@@ -27,7 +24,6 @@ public class StatefulSetBrokerProvisioner extends BasicBrokerProvisioner {
     private static final String NAMESPACE_CONFIG = "kubernetes.namespace";
     private String _namespace;
     private static final Logger LOG = LoggerFactory.getLogger(StatefulSetBrokerProvisioner.class);
-
 
     @Override
     public void configure(Map<String, ?> configs) {
@@ -42,7 +38,7 @@ public class StatefulSetBrokerProvisioner extends BasicBrokerProvisioner {
     @Override
     protected ProvisionerState addOrRemoveBrokers(ProvisionRecommendation rec) {
 
-        try (final KubernetesClient client = new KubernetesClientBuilder().build()) {
+        try (KubernetesClient client = new KubernetesClientBuilder().build()) {
             Integer currentNumReplicas = client
                     .apps()
                     .statefulSets()

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionProposal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionProposal.java
@@ -243,6 +243,10 @@ public class ExecutionProposal {
     return (_replicasToAdd.size() + _replicasToMoveBetweenDisksByBroker.size()) * _partitionSize;
   }
 
+  public long partitionSize() {
+    return _partitionSize;
+  }
+
   private void validate() {
     // Verify old leader exists.
     if (_oldLeader.brokerId() >= 0 && !_oldReplicas.contains(_oldLeader)) {
@@ -289,7 +293,7 @@ public class ExecutionProposal {
     ExecutionProposal otherProposal = (ExecutionProposal) other;
 
     return _tp.equals(otherProposal._tp)
-        && _oldLeader == otherProposal._oldLeader
+        && _oldLeader.equals(otherProposal._oldLeader)
         && _oldReplicas.equals(otherProposal._oldReplicas)
         && _newReplicas.equals(otherProposal._newReplicas);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTask.java
@@ -169,6 +169,10 @@ public class ExecutionTask implements Comparable<ExecutionTask> {
     return _brokerId;
   }
 
+  public long alertTimeMs() {
+    return _alertTimeMs;
+  }
+
   /**
    * Mark task in progress.
    *

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/SingleReplicaMovementStrategy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/SingleReplicaMovementStrategy.java
@@ -25,6 +25,22 @@ public class SingleReplicaMovementStrategy extends BaseReplicaMovementStrategy {
         return expandExecutionTasks(tasks);
     }
 
+    @Override
+    public ReplicaMovementStrategy chain(ReplicaMovementStrategy strategy) {
+        throw new RuntimeException("it is invalid to chain other replica movement strategies to SingleReplicaMovementStrategy");
+    }
+
+    /**
+     * This strategy does not need to be chained to {@link BaseReplicaMovementStrategy} because it
+     * enforces the ordering from it already.
+     *
+     * @return This unchained replica movement strategy.
+     */
+    @Override
+    public ReplicaMovementStrategy chainBaseReplicaMovementStrategyIfAbsent() {
+        return this;
+    }
+
     /**
      * Takes an unordered set of {@link ExecutionTask} and expands any {@link ExecutionTask}
      * that contains multiple replica movements into ordered sets of {@link ExecutionTask} that

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/SingleReplicaMovementStrategy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/SingleReplicaMovementStrategy.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+package com.linkedin.kafka.cruisecontrol.executor.strategy;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
+import com.linkedin.kafka.cruisecontrol.executor.ExecutionTask;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class SingleReplicaMovementStrategy extends BaseReplicaMovementStrategy {
+    @Override
+    public String name() {
+        return SingleReplicaMovementStrategy.class.getSimpleName();
+    }
+
+    @Override
+    protected SortedSet<ExecutionTask> preprocessReplicaMovements(Set<ExecutionTask> tasks) {
+        return expandExecutionTasks(tasks);
+    }
+
+    /**
+     * Takes an unordered set of {@link ExecutionTask} and expands any {@link ExecutionTask}
+     * that contains multiple replica movements into ordered sets of {@link ExecutionTask} that
+     * contain single replica movements.
+     * <br>
+     * The resulting set of {@link ExecutionTask} must remain ordered in order for the proposed
+     * distributions to be enacted by the executor correctly.
+     *
+     * @param replicaMovementTasks The proposed replica movement tasks.
+     * @return The expanded replica movement tasks with only one replica movement per task.
+     */
+    @VisibleForTesting
+    static SortedSet<ExecutionTask> expandExecutionTasks(Set<ExecutionTask> replicaMovementTasks) {
+        SortedSet<ExecutionTask> expanded = new TreeSet<>();
+        long executionTaskId = 0;
+
+        for (ExecutionTask task : replicaMovementTasks) {
+            ExecutionProposal proposal = task.proposal();
+
+            // We sort toAdd and toRemove to put the new and old leaders first (respectively, and if
+            // applicable). If there is a leadership movement, we'll move the leader first.
+            List<ReplicaPlacementInfo> toAdd = proposal.replicasToAdd().stream()
+                    .sorted(ReplicaPlacementInfo.LeaderFirstComparator.of(proposal.newLeader()))
+                    .collect(Collectors.toList());
+            List<ReplicaPlacementInfo> toRemove = proposal.replicasToRemove().stream()
+                    .sorted(ReplicaPlacementInfo.LeaderFirstComparator.of(proposal.oldLeader()))
+                    .collect(Collectors.toList());
+
+            if (toAdd.size() <= 1) {
+                // There is only one replica movement in this execution task; there is no need to expand it, but
+                // we do need to assign it a new execution task id.
+                expanded.add(new ExecutionTask(executionTaskId++, task.proposal(), task.type(), task.alertTimeMs()));
+                continue;
+            }
+
+            // There are multiple replica movements in this execution task; split each replica movement into
+            // its own execution proposal.
+            int i;
+            List<ReplicaPlacementInfo> transitionReplicas = proposal.oldReplicas();
+            for (i = 0; i < toAdd.size(); i++) {
+                List<ReplicaPlacementInfo> nextReplicas = new ArrayList<>(transitionReplicas);
+                if (i < toRemove.size()) {
+                    nextReplicas.remove(toRemove.get(i));
+                }
+                nextReplicas.add(toAdd.get(i));
+
+                if (toAdd.get(i).equals(proposal.newLeader())) {
+                    // If the broker we're adding is the new leader, make sure that broker is first in the replica set.
+                    int leaderPos = nextReplicas.indexOf(proposal.newLeader());
+                    nextReplicas.set(leaderPos, nextReplicas.get(0));
+                    nextReplicas.set(0, proposal.newLeader());
+                }
+
+                expanded.add(new ExecutionTask(
+                        executionTaskId++,
+                        new ExecutionProposal(
+                                proposal.topicPartition(),
+                                proposal.partitionSize(),
+                                transitionReplicas.get(0),
+                                new ArrayList<>(transitionReplicas),
+                                new ArrayList<>(nextReplicas)),
+                        task.type(),
+                        task.alertTimeMs()));
+                transitionReplicas = nextReplicas;
+            }
+
+            if (i < toRemove.size()) {
+                // Any remaining brokers that need to be dropped from the replica set can be safely done in a
+                // single task.
+                List<ReplicaPlacementInfo> nextReplicas = new ArrayList<>(transitionReplicas);
+                for (; i < toRemove.size(); i++) {
+                    nextReplicas.remove(toRemove.get(i));
+                }
+                expanded.add(new ExecutionTask(
+                        executionTaskId++,
+                        new ExecutionProposal(
+                                proposal.topicPartition(),
+                                proposal.partitionSize(),
+                                transitionReplicas.get(0),
+                                new ArrayList<>(transitionReplicas),
+                                new ArrayList<>(nextReplicas)),
+                        task.type(),
+                        task.alertTimeMs()));
+            }
+        }
+
+        return expanded;
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaPlacementInfo.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ReplicaPlacementInfo.java
@@ -4,6 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.model;
 
+import java.util.Comparator;
 import java.util.Objects;
 
 
@@ -48,6 +49,29 @@ public class ReplicaPlacementInfo {
       return String.format("{Broker: %d}", _brokerId);
     } else {
       return String.format("{Broker: %d, Logdir: %s}", _brokerId, _logdir);
+    }
+  }
+
+  public static final class LeaderFirstComparator implements Comparator<ReplicaPlacementInfo> {
+    private final ReplicaPlacementInfo _leader;
+
+    private LeaderFirstComparator(ReplicaPlacementInfo leader) {
+      _leader = leader;
+    }
+
+    public static LeaderFirstComparator of(ReplicaPlacementInfo leader) {
+      return new LeaderFirstComparator(leader);
+    }
+
+    @Override
+    public int compare(ReplicaPlacementInfo a, ReplicaPlacementInfo b) {
+      if (a.equals(_leader)) {
+        return -1;
+      } else if (b.equals(_leader)) {
+        return 1;
+      } else {
+        return 0;
+      }
     }
   }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/strategy/SingleReplicaMovementStrategyTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/strategy/SingleReplicaMovementStrategyTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2023 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+package com.linkedin.kafka.cruisecontrol.executor.strategy;
+
+import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
+import com.linkedin.kafka.cruisecontrol.executor.ExecutionTask;
+import com.linkedin.kafka.cruisecontrol.model.ReplicaPlacementInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class SingleReplicaMovementStrategyTest {
+    @Test
+    public void testExpandExecutionTasks() {
+        TopicPartition tp0 = new TopicPartition("foobar", 0);
+        TopicPartition tp1 = new TopicPartition("foobar", 1);
+        TopicPartition tp2 = new TopicPartition("foobar", 2);
+        TopicPartition tp3 = new TopicPartition("foobar", 3);
+        TopicPartition tp4 = new TopicPartition("foobar", 4);
+        TopicPartition tp5 = new TopicPartition("foobar", 5);
+        TopicPartition tp6 = new TopicPartition("foobar", 6);
+        TopicPartition tp7 = new TopicPartition("foobar", 7);
+
+        // AbstractReplicaMovementStrategy.expandExecutionTasks takes an unordered set, but we give it an
+        // ordered set here to make it easier to test.
+        SortedSet<ExecutionTask> tasks = new TreeSet<>();
+        // Completely replace the replica set (3 replica movements).
+        tasks.add(new ExecutionTask(
+                0,
+                new ExecutionProposal(
+                        tp0,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(4, 5, 6)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Replacing a follower (1 replica movement).
+        tasks.add(new ExecutionTask(
+                1,
+                new ExecutionProposal(
+                        tp1,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(1, 2, 4)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Replacing 2 followers (2 replica movements).
+        tasks.add(new ExecutionTask(
+                2,
+                new ExecutionProposal(
+                        tp2,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(1, 4, 5)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Replacing the leader (1 replica movement).
+        tasks.add(new ExecutionTask(
+                3,
+                new ExecutionProposal(
+                        tp3,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(4, 2, 3)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Changing from RF=3 to RF=2 (1 replica movement).
+        tasks.add(new ExecutionTask(
+                4,
+                new ExecutionProposal(
+                        tp4,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(1, 2)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Changing from RF=4 to RF=2 (still 1 replica movement).
+        tasks.add(new ExecutionTask(
+                5,
+                new ExecutionProposal(
+                        tp5,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3, 4),
+                        replicaSet(1, 2)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Changing from RF=1 to RF=2 (1 replica movement).
+        tasks.add(new ExecutionTask(
+                6,
+                new ExecutionProposal(
+                        tp6,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1),
+                        replicaSet(1, 2)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Changing from RF=1 to RF=3 (2 replica movements).
+        tasks.add(new ExecutionTask(
+                7,
+                new ExecutionProposal(
+                        tp7,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1),
+                        replicaSet(1, 2, 3)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+
+        List<ExecutionTask> actual = new ArrayList<>(SingleReplicaMovementStrategy.expandExecutionTasks(tasks));
+
+        List<ExecutionTask> expected = new ArrayList<>();
+        // Completely replace the replica set (3 replica movements).
+        expected.add(new ExecutionTask(
+                0,
+                new ExecutionProposal(
+                        tp0,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(4, 3, 2)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        expected.add(new ExecutionTask(
+                1,
+                new ExecutionProposal(
+                        tp0,
+                        20,
+                        new ReplicaPlacementInfo(4),
+                        replicaSet(4, 3, 2),
+                        replicaSet(4, 2, 6)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        expected.add(new ExecutionTask(
+                2,
+                new ExecutionProposal(
+                        tp0,
+                        20,
+                        new ReplicaPlacementInfo(4),
+                        replicaSet(4, 2, 6),
+                        replicaSet(4, 6, 5)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Replacing a follower (1 replica movement).
+        expected.add(new ExecutionTask(
+                3,
+                new ExecutionProposal(
+                        tp1,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(1, 2, 4)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Replacing 2 followers (2 replica movements).
+        expected.add(new ExecutionTask(
+                4,
+                new ExecutionProposal(
+                        tp2,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(1, 2, 5)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        expected.add(new ExecutionTask(
+                5,
+                new ExecutionProposal(
+                        tp2,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 5),
+                        replicaSet(1, 5, 4)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Replacing the leader (1 replica movement).
+        expected.add(new ExecutionTask(
+                6,
+                new ExecutionProposal(
+                        tp3,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(4, 2, 3)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Changing from RF=3 to RF=2 (1 replica movement).
+        expected.add(new ExecutionTask(
+                7,
+                new ExecutionProposal(
+                        tp4,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3),
+                        replicaSet(1, 2)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Changing from RF=4 to RF=2 (still 1 replica movement).
+        expected.add(new ExecutionTask(
+                8,
+                new ExecutionProposal(
+                        tp5,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 2, 3, 4),
+                        replicaSet(1, 2)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Changing from RF=1 to RF=2 (1 replica movement).
+        expected.add(new ExecutionTask(
+                9,
+                new ExecutionProposal(
+                        tp6,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1),
+                        replicaSet(1, 2)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        // Changing from RF=1 to RF=3 (2 replica movements).
+        expected.add(new ExecutionTask(
+                10,
+                new ExecutionProposal(
+                        tp7,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1),
+                        replicaSet(1, 3)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+        expected.add(new ExecutionTask(
+                11,
+                new ExecutionProposal(
+                        tp7,
+                        20,
+                        new ReplicaPlacementInfo(1),
+                        replicaSet(1, 3),
+                        replicaSet(1, 3, 2)),
+                ExecutionTask.TaskType.INTER_BROKER_REPLICA_ACTION,
+                1000));
+
+        Assert.assertEquals(expected.size(), actual.size());
+
+        for (int i = 0; i < expected.size(); i++) {
+            Assert.assertEquals(expected.get(i).executionId(), actual.get(i).executionId());
+            Assert.assertEquals(expected.get(i).type(), actual.get(i).type());
+            Assert.assertEquals(expected.get(i).alertTimeMs(), actual.get(i).alertTimeMs());
+
+            Assert.assertEquals(expected.get(i).proposal(), actual.get(i).proposal());
+        }
+    }
+
+    private List<ReplicaPlacementInfo> replicaSet(int... brokerIds) {
+        List<ReplicaPlacementInfo> replicaSet = new ArrayList<>();
+
+        for (int brokerId : brokerIds) {
+            replicaSet.add(new ReplicaPlacementInfo(brokerId));
+        }
+
+        return replicaSet;
+    }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/strategy/SingleReplicaMovementStrategyTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/strategy/SingleReplicaMovementStrategyTest.java
@@ -261,6 +261,11 @@ public class SingleReplicaMovementStrategyTest {
         }
     }
 
+    @Test
+    public void testThrowsRuntimeExceptionWhenChained() {
+        Assert.assertThrows(RuntimeException.class, () -> new SingleReplicaMovementStrategy().chain(new BaseReplicaMovementStrategy()));
+    }
+
     private List<ReplicaPlacementInfo> replicaSet(int... brokerIds) {
         List<ReplicaPlacementInfo> replicaSet = new ArrayList<>();
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSamplerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/monitor/sampling/prometheus/PrometheusMetricSamplerTest.java
@@ -80,22 +80,6 @@ public class PrometheusMetricSamplerTest {
         _prometheusQueryMap = prometheusQuerySupplier.get();
     }
 
-    @Test(expected = ConfigException.class)
-    public void testConfigureWithPrometheusEndpointNoPortFails() throws Exception {
-        Map<String, Object> config = new HashMap<>();
-        config.put(PROMETHEUS_SERVER_ENDPOINT_CONFIG, "http://kafka-cluster-1.org");
-        addCapacityConfig(config);
-        _prometheusMetricSampler.configure(config);
-    }
-
-    @Test(expected = ConfigException.class)
-    public void testConfigureWithPrometheusEndpointNegativePortFails() throws Exception {
-        Map<String, Object> config = new HashMap<>();
-        config.put(PROMETHEUS_SERVER_ENDPOINT_CONFIG, "http://kafka-cluster-1.org:-20");
-        addCapacityConfig(config);
-        _prometheusMetricSampler.configure(config);
-    }
-
     @Test
     public void testConfigureWithPrometheusEndpointNoSchemaDoesNotFail() throws Exception {
         Map<String, Object> config = new HashMap<>();


### PR DESCRIPTION
This PR adds `SingleReplicaMovementStrategy` which operates like `BaseReplicaMovementStrategy` except that it expands any execution tasks that contain multiple replica movements into multiple executions tasks that contain single replica movements.